### PR TITLE
Fix PlatformIO build

### DIFF
--- a/ESP32CAM-TF/platformio.ini
+++ b/ESP32CAM-TF/platformio.ini
@@ -12,10 +12,10 @@
 build_unflags=-Werror=all
 
 [env:esp32cam]
-platform = espressif32
+platform = espressif32@3.2.0
 board = esp32cam
 framework = espidf
 board_build.partitions = partitions.csv
 monitor_speed = 115200
 lib_deps =
-  esp32-camera
+  esp32-camera@1.0.0


### PR DESCRIPTION
Restores the old build by declaring the platform and library version that was available at the time the project was last updated (April 2021). 

```
Checking size .pio\build\esp32cam\firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [=         ]  12.6% (used 41384 bytes from 327680 bytes)
Flash: [======    ]  63.3% (used 830280 bytes from 1310720 bytes)
Building .pio\build\esp32cam\firmware.bin
```

When a PlatformIO user has the latest platform installed, compilation will not work, as seen in #1 and #2.

Rolling back to `platform = espressif32@3.2.0` was done to keep all backwards compatibility. Using the latest `platform = espressif32@3.5.0` does not compile, ends with an incomaptibilty with esp32-camera@1.0.0 version then.

```
.pio/libdeps/esp32cam/esp32-camera@1.0.0/driver/twi.c:61:24: error: 'rtc_gpio_desc' undeclared (first use in this function); did you mean 'rtc_io_desc'?
     uint32_t rtc_reg = rtc_gpio_desc[pin].reg;
                        ^~~~~~~~~~~~~
                        rtc_io_desc
```

In general it might be advisable to try and upgrade this project to the latest Epsressif32 and esp32-cam library version.